### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -4,7 +4,7 @@ $(function(){
     if (message.image) {
       html =
       `
-      <div class="message">
+      <div class="message" data-message-id=${message.id}>
         <div class="message__upper-info">
           <p class="message__upper-info__talker">${message.user_name}</p>
           <p class="message__upper-info__date">${message.created_at}</p>
@@ -17,7 +17,7 @@ $(function(){
     else {
       html =
       `
-      <div class="message">
+      <div class="message" data-message-id=${message.id}>
         <div class="message__upper-info">
           <p class="message__upper-info__talker">${message.user_name}</p>
           <p class="message__upper-info__date">${message.created_at}</p>
@@ -55,15 +55,10 @@ $(function(){
   });
 
   let reloadMessages = function() {
-    // カスタムデータ属性を利用し
-    // ブラウザに表示されている
-    // 最新メッセージのidを取得
     let last_message_id = $('.message:last').data("message-id");
     $.ajax({
-      // ルーティングで設定した通りhttpメソッドをgetに指定
       type: 'GET',
       dataType: 'json',
-      // dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
     .done(function(messages) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -53,4 +53,24 @@ $(function(){
       $('.submit-btn').prop('disabled', false);
     });
   });
+
+  let reloadMessages = function() {
+    // カスタムデータ属性を利用し
+    // ブラウザに表示されている
+    // 最新メッセージのidを取得
+    let last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      // ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'GET',
+      dataType: 'json',
+      // dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -62,7 +62,11 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log('success');
+      let insertHTML = '';
+      $.each(messages, function(i,message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
     })
     .fail(function() {
       alert('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -62,14 +62,18 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      let insertHTML = '';
-      $.each(messages, function(i,message) {
-        insertHTML += buildHTML(message)
-      });
-      $('.messages').append(insertHTML);
+      if (messages.length !== 0) {
+        let insertHTML = '';
+        $.each(messages, function(i,message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }
     })
     .fail(function() {
       alert('error');
     });
   };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -57,6 +57,7 @@ $(function(){
   let reloadMessages = function() {
     let last_message_id = $('.message:last').data("message-id");
     $.ajax({
+      url: 'api/messages',
       type: 'GET',
       dataType: 'json',
       data: {id: last_message_id}

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -75,5 +75,8 @@ $(function(){
       alert('error');
     });
   };
-  setInterval(reloadMessages, 7000);
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }  
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,14 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中に
+    # group_idというキーでグループのidが入るので
+    # これを基にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージから
+    # idがlast_message_idよりも
+    # 新しい(大きい)メッセージのみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.text
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json_user_name message.user.json_user_name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -2,6 +2,6 @@ json.array! @messages do |message|
   json.text message.text
   json.image message.image.url
   json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json_user_name message.user.json_user_name
+  json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     %p.message__upper-info__talker<
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.text @message.text
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
チャットが自動で更新されるようにする。

#Why
今でも自分が投稿した場合は非同期で画面に表示されるが
別のユーザーの投稿メッセージはリロードしなければ表示されない。
これではチャットとは言えないので自動でチャット画面が更新されるようにする。